### PR TITLE
Add volcengine sdk to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ PyMySQL==1.1.1
 python-dateutil==2.9.0.post0
 requests==2.32.3
 pillow==11.2.1
+volcengine-python-sdk[ark]


### PR DESCRIPTION
## Summary
- include `volcengine-python-sdk[ark]` in requirements

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6842aa0514a483209a7d53ea44532158